### PR TITLE
Fixed flashing tab colors in some sites

### DIFF
--- a/background.js
+++ b/background.js
@@ -181,8 +181,10 @@ function changeFrameColorToBackground() {
       let url = tabs[0].url;
       let windowId = tabs[0].windowId;
       if (response == undefined){
-        resetFrameColor(windowId);
-        console.log("NO CONNECTION TO CONTENT SCRIPT\nMay be about:pages");
+        if (url.startsWith("about:") || url.startsWith("addons.mozilla.org")) {
+          resetFrameColor(windowId);
+          console.log("about:pages or addons.mozilla.org detected");
+        }
       }
     });
   });


### PR DESCRIPTION
The flashes occurs when resetFrameColor(windowId) is triggered when one of those conditions are met:

- Site is starting to load and DOM has not been fully processed, entering a race condition which will turn into `response == undefined`
- Site is reserved by Firefox, such as about:pages or addons.mozilla.org and will always get `response == undefined` because they can't message to `content_script.js` due to security policies.

In the first case, it will eventually get the proper color once the DOM has finished loading. But in the current code, it will trigger `resetFrameColor(windowId)` for just a moment, producing the color flash in the tabs. Easy to solve by just ignoring the `resetFrameColor` function. But what about the reserved sites?

Well, the best solution would be to check if the current site is one of the reserved ones and just trigger `resetFrameColor` when we're in one of those :)

Flashes solved. Reserved pages will keep working normally.

