### PR TITLE
White theme for transparent pages

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -127,8 +127,6 @@ function getComputedColor() {
 		if (element.offsetWidth / window.innerWidth >= 0.8 && element.offsetHeight >= 20)
 			color = overlayColor(color, ANY_to_RGBA(getColorFrom(element)));
 	}
-	if (color.a == 0)
-		return "rgb(255, 255, 255)";
 	if (color.a != 1) {
 		let body = document.getElementsByTagName("body")[0];
 		if (body == undefined) {
@@ -297,7 +295,7 @@ function HSLA_to_RGBA(hsla) {
 function overlayColor(top, bottom) {
 	let a = (1 - top.a) * bottom.a + top.a;
 	if (a == 0) {
-		return { r: 0, g: 0, b: 0, a: 0 };
+		return { r: 255, g: 255, b: 255, a: 0 };
 	} else {
 		return {
 			r: ((1 - top.a) * bottom.a * bottom.r + top.a * top.r) / a,

--- a/content_script.js
+++ b/content_script.js
@@ -127,6 +127,8 @@ function getComputedColor() {
 		if (element.offsetWidth / window.innerWidth >= 0.8 && element.offsetHeight >= 20)
 			color = overlayColor(color, ANY_to_RGBA(getColorFrom(element)));
 	}
+	if (color.a == 0)
+		return "rgb(255, 255, 255)";
 	if (color.a != 1) {
 		let body = document.getElementsByTagName("body")[0];
 		if (body == undefined) {

--- a/content_script.js
+++ b/content_script.js
@@ -295,7 +295,8 @@ function HSLA_to_RGBA(hsla) {
 function overlayColor(top, bottom) {
 	let a = (1 - top.a) * bottom.a + top.a;
 	if (a == 0) {
-		return { r: 255, g: 255, b: 255, a: 0 };
+		// Firefox renders transparent background in this color
+		return { r: 236, g: 236, b: 236, a: 0 };
 	} else {
 		return {
 			r: ((1 - top.a) * bottom.a * bottom.r + top.a * top.r) / a,


### PR DESCRIPTION
If the element at the top is transparent, theme color should be set to white.

Before the update, transparent background would cause rgb(0, 0, 0) theme color (black), while the browser would render transparent background as white. This would create a mismatch between the page and browser theme. The problem was spotted on skelbiu.lt - the change may be tested there.