### PR TITLE
Show line of death

### DIFF
--- a/background.js
+++ b/background.js
@@ -25,7 +25,7 @@ var adaptive_themes = {
       tab_line: "rgba(0, 0, 0, 0)",
       popup_border: "rgba(0, 0, 0, 0)",
       sidebar_border: "rgba(0, 0, 0, 0)",
-      toolbar_bottom_separator: "rgba(0, 0, 0, 0)",
+      toolbar_bottom_separator: "rgba(0,0,0, .2)",
       toolbar_top_separator: "rgba(0, 0, 0, 0)",
       tab_loading: "rgba(0, 0, 0, 0)",
     }
@@ -56,7 +56,7 @@ var adaptive_themes = {
       tab_line: "rgba(0, 0, 0, 0)",
       popup_border: "rgba(0, 0, 0, 0)",
       sidebar_border: "rgba(0, 0, 0, 0)",
-      toolbar_bottom_separator: "rgba(0, 0, 0, 0)",
+      toolbar_bottom_separator: "rgba(255,255,255,0.2)",
       toolbar_top_separator: "rgba(0, 0, 0, 0)",
       tab_loading: "rgba(0, 0, 0, 0)",
     }
@@ -87,7 +87,7 @@ var adaptive_themes = {
       tab_line: "rgba(0, 0, 0, 0)",
       popup_border: "rgba(0, 0, 0, 0)",
       sidebar_border: "rgba(0, 0, 0, 0)",
-      toolbar_bottom_separator: "rgba(0, 0, 0, 0)",
+      toolbar_bottom_separator: "rgba(255,255,255,0.2)",
       toolbar_top_separator: "rgba(0, 0, 0, 0)",
       tab_loading: "rgba(0, 0, 0, 0)",
     },
@@ -525,7 +525,6 @@ function changeThemePara(color, color_scheme, change_ntp_bg) {
   adaptive_themes[color_scheme]["colors"]["frame_inactive"] = frame_color;
   adaptive_themes[color_scheme]["colors"]["popup"] = popup_color;
   adaptive_themes[color_scheme]["colors"]["toolbar"] = toolbar_color;
-  adaptive_themes[color_scheme]["colors"]["toolbar_bottom_separator"] = toolbar_color;
   adaptive_themes[color_scheme]["colors"]["toolbar_field"] = popup_color;
   adaptive_themes[color_scheme]["colors"]["toolbar_field_focus"] = popup_color;
   if (change_ntp_bg) adaptive_themes[color_scheme]["colors"]["ntp_background"] = ntp_color;

--- a/background.js
+++ b/background.js
@@ -108,6 +108,7 @@ var pref_force;
 var pref_dynamic;
 var pref_tabbar_color;
 var pref_toolbar_color;
+var pref_separator_opacity;
 var pref_popup_color;
 var pref_custom;
 var pref_light_color;
@@ -195,6 +196,7 @@ function loadPref(pref) {
   pref_dynamic = pref.dynamic;
   pref_tabbar_color = pref.tabbar_color;
   pref_toolbar_color = pref.toolbar_color;
+  pref_separator_opacity = pref.separator_opacity;
   pref_popup_color = pref.popup_color;
   pref_custom = pref.custom;
   pref_light_color = pref.light_color;
@@ -242,6 +244,7 @@ function init() {
     let pending_dynamic = pref_dynamic;
     let pending_tabbar_color = pref_tabbar_color;
     let pending_toolbar_color = pref_toolbar_color;
+    let pending_separator_opacity = pref_separator_opacity;
     let pending_popup_color = pref_popup_color;
     let pending_custom = pref_custom;
     let pending_light_color = pref_light_color;
@@ -251,6 +254,9 @@ function init() {
     //updates from v1.6.3 or earlier
     if (pref_toolbar_color == null) {
       pending_toolbar_color = 0;
+    }
+    if (pref_separator_opacity == null) {
+      pending_separator_opacity = .2;
     }
     //updates from v1.6.2 or earlier
     if (pref_tabbar_color == null || pref_popup_color == null) {
@@ -293,6 +299,7 @@ function init() {
       dynamic: pending_dynamic,
       tabbar_color: pending_tabbar_color,
       toolbar_color: pending_toolbar_color,
+      separator_opacity: pending_separator_opacity,
       popup_color: pending_popup_color,
       custom: pending_custom,
       light_color: pending_light_color,
@@ -505,26 +512,30 @@ function changeFrameColorTo(windowId, color, dark_mode) {
  * @param {boolean} change_ntp_bg Determines if to change color of New Tab Page.
  */
 function changeThemePara(color, color_scheme, change_ntp_bg) {
-  let frame_color, toolbar_color, popup_color, ntp_color;
+  let frame_color, toolbar_color, popup_color, ntp_color, separator_color;
   if (color_scheme == "dark") {
     frame_color = dimColor(color, pref_tabbar_color);
     toolbar_color = pref_toolbar_color == pref_tabbar_color ? "rgba(0, 0, 0, 0)" : dimColor(color, pref_toolbar_color);
+    separator_color = dimColor(color, pref_separator_opacity);
     popup_color = dimColor(color, pref_popup_color);
     ntp_color = dimColor(color, 0);
   } else if (color_scheme == "light") {
     frame_color = dimColor(color, -pref_tabbar_color);
     popup_color = dimColor(color, -pref_popup_color);
+    separator_color = dimColor(color, -pref_separator_opacity);
     toolbar_color = pref_toolbar_color == pref_tabbar_color ? "rgba(0, 0, 0, 0)" : dimColor(color, -pref_toolbar_color);
     ntp_color = dimColor(color, 0);
   } else if (color_scheme == "darknoise") {
     frame_color = "rgb(33, 33, 33)";
     popup_color = dimColor(color, pref_popup_color);
+    separator_color = dimColor(color, pref_separator_opacity);
     toolbar_color = "rgba(0, 0, 0, 0)";
   }
   adaptive_themes[color_scheme]["colors"]["frame"] = frame_color;
   adaptive_themes[color_scheme]["colors"]["frame_inactive"] = frame_color;
   adaptive_themes[color_scheme]["colors"]["popup"] = popup_color;
   adaptive_themes[color_scheme]["colors"]["toolbar"] = toolbar_color;
+  adaptive_themes[color_scheme]["colors"]["toolbar_bottom_separator"] = separator_color;
   adaptive_themes[color_scheme]["colors"]["toolbar_field"] = popup_color;
   adaptive_themes[color_scheme]["colors"]["toolbar_field_focus"] = popup_color;
   if (change_ntp_bg) adaptive_themes[color_scheme]["colors"]["ntp_background"] = ntp_color;

--- a/options.html
+++ b/options.html
@@ -56,14 +56,14 @@
 				<label for="toolbar_color" class="TenEm">Toolbar color offset</label>
 				<input type="range" id="toolbar_color" min="0" max="0.2" step="0.05" value="0">
 			</h4>
-			<h4
-				title="Color offset of separator line between browser UI and webpage">
-				<label for="separator_opacity" class="TenEm">Opacity of separator line</label>
-				<input type="range" id="separator_opacity" min="0" max="1" step=".1" value=".2">
-			</h4>
 			<h4 title="Set pop-up and URL field color offset">
 				<label for="popup_color" class="TenEm">URL field color offset</label>
 				<input type="range" id="popup_color" min="0" max="0.2" step="0.05" value="0.05">
+			</h4>
+			<h4
+					title="Color offset of separator line between browser UI and webpage">
+				<label for="separator_opacity" class="TenEm">Opacity of separator line</label>
+				<input type="range" id="separator_opacity" min="0" max="1" step="0.05" value=".2">
 			</h4>
 			<hr>
 			<h4>

--- a/options.html
+++ b/options.html
@@ -56,6 +56,11 @@
 				<label for="toolbar_color" class="TenEm">Toolbar color offset</label>
 				<input type="range" id="toolbar_color" min="0" max="0.2" step="0.05" value="0">
 			</h4>
+			<h4
+				title="Color offset of separator line between browser UI and webpage">
+				<label for="separator_opacity" class="TenEm">Opacity of separator line</label>
+				<input type="range" id="separator_opacity" min="0" max="1" step=".1" value=".2">
+			</h4>
 			<h4 title="Set pop-up and URL field color offset">
 				<label for="popup_color" class="TenEm">URL field color offset</label>
 				<input type="range" id="popup_color" min="0" max="0.2" step="0.05" value="0.05">

--- a/options.js
+++ b/options.js
@@ -22,6 +22,7 @@ let force_mode_caption = document.getElementById("force_mode_caption");
 let dynamic = document.getElementById("dynamic");
 let op_tabbar_color = document.getElementById("tabbar_color");
 let op_toolbar_color = document.getElementById("toolbar_color");
+let op_separator_opacity = document.getElementById("separator_opacity");
 let op_popup_color = document.getElementById("popup_color");
 let op_more_custom = document.getElementById("more_custom");
 let op_custom_options = document.getElementById("custom_options");
@@ -57,6 +58,7 @@ function loadPref(pref) {
 	pref_tabbar_color = pref.tabbar_color;
 	pref_toolbar_color = pref.toolbar_color;
 	pref_popup_color = pref.popup_color;
+	pref_separator_opacity = pref.separator_opacity;
 	pref_custom = pref.custom;
 	pref_light_color = pref.light_color;
 	pref_dark_color = pref.dark_color;
@@ -73,6 +75,7 @@ function verifyPref() {
 		&& pref_tabbar_color != null
 		&& pref_toolbar_color != null
 		&& pref_popup_color != null
+		&& pref_separator_opacity != null
 		&& pref_custom != null
 		&& pref_light_color != null
 		&& pref_dark_color != null
@@ -105,6 +108,7 @@ function load() {
 				op_tabbar_color.value = pref_tabbar_color;
 				op_toolbar_color.value = pref_toolbar_color;
 				op_popup_color.value = pref_popup_color;
+				op_separator_opacity.value = pref_separator_opacity;
 				op_more_custom.checked = pref_custom;
 				op_custom_options.hidden = !pref_custom;
 				op_light_color.value = pref_light_color;
@@ -244,6 +248,9 @@ if (popupDetected()) {
 	op_popup_color.oninput = () => {
 		browser.storage.local.set({ popup_color: Number(op_popup_color.value) });
 	};
+	op_separator_opacity.oninput = () => {
+		browser.storage.local.set({ separator_opacity: Number(op_separator_opacity.value) })
+	}
 	op_more_custom.onclick = () => {
 		browser.storage.local.set({ custom: op_more_custom.checked });
 		op_custom_options.hidden = !op_more_custom.checked;


### PR DESCRIPTION
I just saw the safety warning in your readme and thought this should be easy to fix. Inspired by Chrome on Android, I made the bottom line visible again:
![grafik](https://user-images.githubusercontent.com/46622675/178988053-4c353f88-9632-4885-a291-61eaaa7f487b.png)

If you want, I can make this opt-out